### PR TITLE
Fix(vehicle): Correctly parse formatted mileage strings

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1158,7 +1158,7 @@ const VehicleModal = () => {
                     </div>
                     <div class="form-group">
                         <label for="km">Kilometre</label>
-                        <input type="number" id="km" name="km" placeholder="Örn: 85000" value="${vehicle?.km.replace(/,/, '') || ''}" required>
+                        <input type="number" id="km" name="km" placeholder="Örn: 85000" value="${vehicle?.km.replace(/[^0-9]/g, '') || ''}" required>
                     </div>
                 </div>
                 <div class="form-row">

--- a/test_mileage_fix.html
+++ b/test_mileage_fix.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Mileage Parsing Fix</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+        .test-section { border: 1px solid #ccc; padding: 10px; margin-bottom: 20px; border-radius: 5px; }
+        .result { font-weight: bold; }
+        .pass { color: green; }
+        .fail { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Mileage Parsing Bug Verification</h1>
+
+    <div class="test-section">
+        <h2>Test Case 1: Original Buggy Logic (Failing)</h2>
+        <p>This test demonstrates the original buggy logic from <code>index.tsx</code>. It fails because <code>.replace(/,/, '')</code> only removes the first comma.</p>
+        <script>
+            const testValue1 = "1,234,567";
+            const expectedValue1 = "1234567";
+            const actualValue1 = testValue1.replace(/,/, ''); // The buggy logic
+            const passed1 = actualValue1 === expectedValue1;
+            document.write(`<p>Test Value: <strong>${testValue1}</strong></p>`);
+            document.write(`<p>Expected Value: <strong>${expectedValue1}</strong></p>`);
+            document.write(`<p>Actual Value (Buggy): <strong>${actualValue1}</strong></p>`);
+            document.write(`<p>Result: <span class="result ${passed1 ? 'pass' : 'fail'}">${passed1 ? "PASS" : "FAIL"}</span></p>`);
+        </script>
+    </div>
+
+    <div class="test-section">
+        <h2>Test Case 2: Corrected Logic (Passing)</h2>
+        <p>This test demonstrates the new, robust logic. It passes because <code>.replace(/[^0-9]/g, '')</code> removes all non-numeric characters.</p>
+        <script>
+            const testValue2 = "1,234,567";
+            const expectedValue2 = "1234567";
+            const actualValue2 = testValue2.replace(/[^0-9]/g, ''); // The corrected logic
+            const passed2 = actualValue2 === expectedValue2;
+            document.write(`<p>Test Value: <strong>${testValue2}</strong></p>`);
+            document.write(`<p>Expected Value: <strong>${expectedValue2}</strong></p>`);
+            document.write(`<p>Actual Value (Corrected): <strong>${actualValue2}</strong></p>`);
+            document.write(`<p>Result: <span class="result ${passed2 ? 'pass' : 'fail'}">${passed2 ? "PASS" : "FAIL"}</span></p>`);
+        </script>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
The previous logic for parsing vehicle mileage in the edit modal used `.replace(/,/, '')`, which only removed the first comma from a formatted number string. This caused incorrect values for numbers over 999,999 and failed to handle other locale-specific separators like periods.

This commit changes the parsing logic to use `replace(/[^0-9]/g, '')`, which robustly strips all non-numeric characters from the string. This ensures that any formatted number is correctly parsed, regardless of the number of separators or the locale.

A new test file, `test_mileage_fix.html`, has been added to demonstrate both the failing (original) and passing (corrected) logic, verifying the fix.

## Summary by Sourcery

Replace the single-comma removal in mileage parsing with a regex that removes all non-digits and include a test HTML page to validate both the buggy and fixed behaviors

Bug Fixes:
- Correctly strip all non-numeric characters when parsing formatted mileage strings to handle multiple separators and locales

Tests:
- Add test_mileage_fix.html demonstrating failing original logic and verifying corrected parsing logic